### PR TITLE
Allow hive listener to read from configuration file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,26 @@ Snowflake Hive SDK
 Usage:
 ======
 
-1. Modify the snowflake jdbc connection properties in SnowflakeClient.java
+1. Add a Snowflake configuration file.
+The file should be in the form
+
+.. code-block:: bash
+    <configuration>
+      <property>
+        <name>snowflake.jdbc.username</name>
+        <value>mySnowflakeUsername</value>
+      </property>
+    </configuration>
+
+The properties required are:
+snowflake.jdbc.username
+snowflake.jdbc.password
+snowflake.jdbc.account
+snowflake.jdbc.db
+snowflake.jdbc.schema
+snowflake.jdbc.connection
+
+For more information on the snowflake jdbc driver, see: https://docs.snowflake.net/manuals/user-guide/jdbc.html
 
 2. Package the jar by running:
 

--- a/src/main/java/com/snowflake/conf/SnowflakeJdbcConf.java
+++ b/src/main/java/com/snowflake/conf/SnowflakeJdbcConf.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing Inc. All right reserved.
+ */
+package com.snowflake.conf;
+
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SnowflakeJdbcConf extends Configuration
+{
+  private static final Logger log = LoggerFactory.getLogger(SnowflakeJdbcConf.class);
+  public enum ConfVars
+  {
+    SNOWFLAKE_JDBC_USERNAME("snowflake.jdbc.username", "user",
+      "The user to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_PASSWORD("snowflake.jdbc.password", "password",
+      "The password to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_ACCOUNT("snowflake.jdbc.account", "account",
+      "The account to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_DB("snowflake.jdbc.db", "db",
+      "The database to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_SCHEMA("snowflake.jdbc.schema", "schema",
+      "The schema to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_SSL("snowflake.jdbc.ssl", "ssl",
+      "Use ssl to connect to Snowflake"),
+    SNOWFLAKE_JDBC_CONNECTION("snowflake.jdbc.connection", "connection",
+      "The Snowflake connection string.");
+
+    public static final Map<String, ConfVars> BY_VARNAME =
+        Arrays.stream(ConfVars.values())
+            .collect(Collectors.toMap(e -> e.varname, e -> e));
+
+    public static ConfVars findByName(String varname)
+    {
+      return BY_VARNAME.get(varname);
+    }
+
+    ConfVars(String varname, String snowflakePropertyName,
+             String description)
+    {
+      this.varname = varname;
+      this.snowflakePropertyName = snowflakePropertyName;
+      this.description = description;
+    }
+
+    public String getVarname()
+    {
+      return this.varname;
+    }
+
+    public String getSnowflakePropertyName()
+    {
+      return this.snowflakePropertyName;
+    }
+
+    private final String varname;
+    private final String snowflakePropertyName;
+    private final String description;
+  }
+
+  private static URL snowflakeConfigUrl;
+
+  static
+  {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    if (classLoader == null)
+    {
+      classLoader = SnowflakeJdbcConf.class.getClassLoader();
+    }
+
+    snowflakeConfigUrl = findConfigFile(classLoader, "snowflake-config.xml");
+  }
+
+  private static URL findConfigFile(ClassLoader classLoader, String name)
+  {
+    URL result = classLoader.getResource(name);
+    if(result == null)
+    {
+      log.error("Could not find the Snowflake configuration file. " +
+          "Ensure that it's named snowflake-config.xml and " +
+          "it is in the hive classpath");
+    }
+    return result;
+  }
+
+  private void initialize()
+  {
+    if (snowflakeConfigUrl != null)
+    {
+      addResource(snowflakeConfigUrl);
+    }
+  }
+
+  public SnowflakeJdbcConf()
+  {
+    super(false);
+    initialize();
+  }
+
+}

--- a/src/main/java/com/snowflake/hive/listener/SnowflakeHiveListener.java
+++ b/src/main/java/com/snowflake/hive/listener/SnowflakeHiveListener.java
@@ -3,6 +3,7 @@
  */
 package com.snowflake.hive.listener;
 
+import com.snowflake.conf.SnowflakeJdbcConf;
 import com.snowflake.jdbc.client.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
@@ -19,9 +20,13 @@ public class SnowflakeHiveListener extends MetaStoreEventListener
   private static final Logger log =
       LoggerFactory.getLogger(SnowflakeHiveListener.class);
 
+  private static SnowflakeJdbcConf snowflakeJdbcConf;
+
   public SnowflakeHiveListener(Configuration config)
   {
     super(config);
+    // generate the snowflake jdbc conf
+    snowflakeJdbcConf = new SnowflakeJdbcConf();
     log.info("SnowflakeHiveListener created");
   }
 
@@ -35,7 +40,7 @@ public class SnowflakeHiveListener extends MetaStoreEventListener
     log.info("SnowflakeHiveListener: CreateTableEvent received");
     if (tableEvent.getStatus())
     {
-      SnowflakeClient.createAndExecuteEventForSnowflake(tableEvent);
+      SnowflakeClient.createAndExecuteEventForSnowflake(tableEvent, snowflakeJdbcConf);
     }
   }
 }


### PR DESCRIPTION
These changes allow the hive listener to read snowflake jdbc properties from a configuration file.
Clients would not need to modify the source code and they would be able to establish a connection to Snowflake without making any changes to the SDK.

The configuration properties file should mimic that of Hive with the format as follows:

<configuration>
  <property>
    <name>{propertyname}</name>
    <value>{propertyvalue}</value>
  </property>
</configuration>