### PR TITLE
Fixed handing of __HIVE_DEFAULT_PARTITION__

### DIFF
--- a/src/main/java/com/snowflake/core/commands/AddPartition.java
+++ b/src/main/java/com/snowflake/core/commands/AddPartition.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -105,6 +106,8 @@ public class AddPartition extends Command
         String.join(", ",
                     partitions.stream()
                         .map(this::generatePartitionDetails)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
                         .collect(Collectors.toList())),
         StringUtil.escapeSqlComment(hiveTable.getSd().getLocation()));
   }
@@ -114,8 +117,9 @@ public class AddPartition extends Command
    * @param partition Partition object to generate a portion of a command
    * @return A portion of the command that represents the partition,
    *         for example: PARTITION(partcol='partcolname') LOCATION 'sub/path'
+   *         If the partition cannot be generated, this returns Optional.empty
    */
-  private String generatePartitionDetails(Partition partition)
+  private Optional<String> generatePartitionDetails(Partition partition)
   {
     List<FieldSchema> partitionKeys = hiveTable.getPartitionKeys();
     List<String> partitionValues = partition.getValues();
@@ -132,8 +136,7 @@ public class AddPartition extends Command
       // skip this partition instead.
       if ("__HIVE_DEFAULT_PARTITION__".equalsIgnoreCase(partitionValues.get(i)))
       {
-        return new LogCommand(hiveTable,
-            "Cannot add partition __HIVE_DEFAULT_PARTITION__. Skipping.").generateSqlQueries().get(0);
+        return Optional.empty();
       }
 
       partitionDefinitions.add(
@@ -142,9 +145,10 @@ public class AddPartition extends Command
                         StringUtil.escapeSqlText(partitionValues.get(i))));
     }
 
-    return String.format("PARTITION(%s) LOCATION '%s'",
-                         String.join(",", partitionDefinitions),
-                         StringUtil.escapeSqlText(StringUtil.relativizePartitionURI(hiveTable, partition)));
+    return Optional.of(
+        String.format("PARTITION(%s) LOCATION '%s'",
+                      String.join(",", partitionDefinitions),
+                      StringUtil.escapeSqlText(StringUtil.relativizePartitionURI(hiveTable, partition))));
   }
 
   /**

--- a/src/main/java/com/snowflake/core/commands/AddPartition.java
+++ b/src/main/java/com/snowflake/core/commands/AddPartition.java
@@ -100,15 +100,22 @@ public class AddPartition extends Command
   {
     Preconditions.checkNotNull(partitions);
     Preconditions.checkArgument(!partitions.isEmpty());
+    List<String> partitionDetails = partitions.stream()
+        .map(this::generatePartitionDetails)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+
+    if (partitionDetails.isEmpty())
+    {
+      return new LogCommand(hiveTable, "No partitions to add.")
+          .generateSqlQueries().get(0);
+    }
+
     return String.format(
         "ALTER EXTERNAL TABLE %s ADD %s /* TABLE LOCATION = '%s' */;",
         StringUtil.escapeSqlIdentifier(hiveTable.getTableName()),
-        String.join(", ",
-                    partitions.stream()
-                        .map(this::generatePartitionDetails)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .collect(Collectors.toList())),
+        String.join(", ", partitionDetails),
         StringUtil.escapeSqlComment(hiveTable.getSd().getLocation()));
   }
 

--- a/src/test/java/AddPartitionTest.java
+++ b/src/test/java/AddPartitionTest.java
@@ -220,4 +220,76 @@ public class AddPartitionTest
                      "/* TABLE LOCATION = 's3n://bucketname/path/to/table' */;",
                  combined.get(1).generateSqlQueries().get(2));
   }
+
+  /**
+   * Negative test with a Hive default partition (__HIVE_DEFAULT_PARTITION__)
+   * @throws Exception
+   */
+  @Test
+  public void defaultPartitionAddPartitionGenerateCommandTest() throws Exception
+  {
+    // mock table
+    Table table = TestUtil.initializeMockTable();
+
+    // mock partition
+    Partition partition = new Partition();
+    partition.setValues(Arrays.asList("1", "__HIVE_DEFAULT_PARTITION__"));
+    partition.setSd(new StorageDescriptor());
+    partition.getSd().setLocation("s3n://bucketname/path/to/table/sub/path");
+
+    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+
+    AddPartitionEvent addPartitionEvent =
+        new AddPartitionEvent(table, partition, true, mockHandler);
+
+    AddPartition addPartition = new AddPartition(addPartitionEvent, TestUtil.initializeMockConfig());
+
+    List<String> commands = addPartition.generateSqlQueries();
+    assertEquals(3, commands.size());
+    assertEquals("generated add partition command does not match " +
+                     "expected add partition command",
+                 "SELECT NULL /* No partitions to add. */;",
+                 commands.get(2));
+  }
+
+  /**
+   * Negative test with a Hive default partition (__HIVE_DEFAULT_PARTITION__)
+   * @throws Exception
+   */
+  @Test
+  public void defaultPartitionMultiAddPartitionGenerateCommandTest() throws Exception
+  {
+    // mock table
+    Table table = TestUtil.initializeMockTable();
+
+    // mock partitions
+    Partition partition1 = new Partition();
+    partition1.setValues(Arrays.asList("1", "__HIVE_DEFAULT_PARTITION__"));
+    partition1.setSd(new StorageDescriptor());
+    partition1.getSd().setLocation("s3n://bucketname/path/to/table/sub/path");
+
+    Partition partition2 = new Partition();
+    partition2.setValues(Arrays.asList("2", "testName"));
+    partition2.setSd(new StorageDescriptor());
+    partition2.getSd().setLocation("s3n://bucketname/path/to/table/sub/path2");
+
+    List<Partition> partitions = ImmutableList.of(partition1, partition2);
+
+    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+
+    AddPartitionEvent addPartitionEvent =
+        new AddPartitionEvent(table, partitions, true, mockHandler);
+
+    AddPartition addPartition = new AddPartition(addPartitionEvent, TestUtil.initializeMockConfig());
+
+    List<String> commands = addPartition.generateSqlQueries();
+    assertEquals(3, commands.size());
+    assertEquals("generated add partition command does not match " +
+                     "expected add partition command",
+                 "ALTER EXTERNAL TABLE t1 ADD PARTITION(partcol='2'," +
+                     "name='testName') LOCATION 'sub/path2' /* TABLE LOCATION" +
+                     " " +
+                     "= 's3n://bucketname/path/to/table' */;",
+                 commands.get(2));
+  }
 }


### PR DESCRIPTION
This is a minor fix. We should skip the partition when we encounter one with __HIVE_DEFAULT_PARTITION__ as the partition value. Before the fix, we would create a malformed add partition command.