### PR TITLE
Added tool to sync partitions

### DIFF
--- a/src/main/java/com/snowflake/conf/SnowflakeConf.java
+++ b/src/main/java/com/snowflake/conf/SnowflakeConf.java
@@ -36,6 +36,8 @@ public class SnowflakeConf extends Configuration
       "The role to use to connect to Snowflake."),
     SNOWFLAKE_JDBC_DB("snowflake.jdbc.db", "db",
       "The database to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_WAREHOUSE("snowflake.jdbc.warehouse", "warehouse",
+      "The warehouse to use with Snowflake, if necessary."),
     SNOWFLAKE_JDBC_SCHEMA("snowflake.jdbc.schema", "schema",
       "The schema to use to connect to Snowflake."),
     SNOWFLAKE_JDBC_SSL("snowflake.jdbc.ssl", "ssl",

--- a/src/main/java/com/snowflake/core/util/HiveSyncTool.java
+++ b/src/main/java/com/snowflake/core/util/HiveSyncTool.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing Inc. All right reserved.
+ */
+package com.snowflake.core.util;
+
+import com.google.common.base.Preconditions;
+import com.snowflake.conf.SnowflakeConf;
+import com.snowflake.core.commands.DropPartition;
+import com.snowflake.jdbc.client.SnowflakeClient;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for syncing metadata from Hive to Snowflake
+ * @author wwong
+ */
+public class HiveSyncTool
+{
+  private static final Logger log = LoggerFactory.getLogger(HiveSyncTool.class);
+
+  // Note: HiveMetaStoreClient is not backwards compatible. Notably, 2.X
+  //       versions use a HiveConf argument instead of a Configuration
+  //       argument. Also, if the version of the HiveMetaStoreClient is not
+  //       compatible with the metastore, calls to the metastore may return
+  //       wrong results, e.g. client.getAllDatabases() returns no databases.
+  private final HiveMetaStoreClient hmsClient;
+
+  // The Snowflake configuration
+  private final SnowflakeConf snowflakeConf;
+
+  /**
+   * Instantiates the HiveSyncTool.
+   * @param hmsClient a client for the Hive metastore
+   */
+  public HiveSyncTool(HiveMetaStoreClient hmsClient)
+  {
+    this.hmsClient = hmsClient;
+    this.snowflakeConf = new SnowflakeConf();
+  }
+
+  /**
+   * Does a one-time, one-way metadata sync from the Hive metastore to
+   * Snowflake.
+   * 1. Tables in Hive are created in Snowflake
+   * 2. Partitions not in Hive are dropped from Snowflake
+   * 3. Partitions in Hive are added to Snowflake
+   * Note: does not drop tables from Snowflake.
+   * @throws TException thrown when encountering a Thrift exception while
+   *         communicating with the metastore or executing a metastore operation
+   */
+  public void sync() throws TException
+  {
+    Pattern tableNameFilter = snowflakeConf.getPattern(
+        SnowflakeConf.ConfVars.SNOWFLAKE_TABLE_FILTER_REGEX.getVarname(), null);
+    Pattern databaseNameFilter = snowflakeConf.getPattern(
+        SnowflakeConf.ConfVars.SNOWFLAKE_DATABASE_FILTER_REGEX.getVarname(), null);
+
+    log.info("Starting sync");
+    List<String> databaseNames = hmsClient.getAllDatabases().stream()
+        .filter(db -> databaseNameFilter == null || !databaseNameFilter.matcher(db).matches())
+        .collect(Collectors.toList());
+    log.info(String.format("Syncing %s databases from Hive",
+                           databaseNames.size()));
+    for (String databaseName : databaseNames)
+    {
+      Preconditions.checkNotNull(databaseName);
+      List<String> tableNames = hmsClient.getAllTables(databaseName).stream()
+          .filter(table -> tableNameFilter == null || !tableNameFilter.matcher(table).matches())
+          .collect(Collectors.toList());
+      log.info(String.format("Syncing %s tables for database %s",
+                             tableNames.size(), databaseName));
+      for (String tableName : tableNames)
+      {
+        Preconditions.checkNotNull(tableName);
+
+        // Do a touch on the table to fire listener events
+        Table hiveTable = hmsClient.getTable(databaseName, tableName);
+        hmsClient.alter_table(databaseName, tableName, hiveTable);
+
+        if (!hiveTable.getPartitionKeys().isEmpty())
+        {
+          // Drop extra partitions
+          dropExtraPartitionsFromSnowflake(databaseName, hiveTable);
+        }
+
+        // Do a touch on all partitions to fire listener events
+        List<Partition> partitions = hmsClient.listPartitions(
+            databaseName, tableName, (short) -1 /* all partitions */);
+        log.info(String.format("Syncing %s partitions for table %s.%s",
+                               partitions.size(), tableName, databaseName));
+        hmsClient.alter_partitions(databaseName, tableName, partitions);
+      }
+    }
+    log.info("Sync complete");
+  }
+
+  /**
+   * Helper method that drops extra partitions from Snowflake if they are
+   * not in Hive.
+   * @throws TException thrown when encountering a Thrift exception while
+   *         communicating with the metastore or executing a metastore operation
+   */
+  private void dropExtraPartitionsFromSnowflake(String databaseName,
+                                                Table hiveTable)
+      throws TException
+  {
+    Preconditions.checkNotNull(databaseName);
+    Preconditions.checkNotNull(Preconditions.checkNotNull(hiveTable).getTableName());
+
+    // Get Snowflake partition locations
+    Set<String> sfPartLocs;
+    try
+    {
+      sfPartLocs = getSnowflakePartitionLocations(hiveTable);
+    }
+    catch (IllegalStateException | SQLException ex)
+    {
+      log.warn(String.format(
+          "Error encountered, skipping dropping partitions for table %s. Error: %s",
+          hiveTable.getTableName(), ex));
+      return;
+    }
+
+    // Listing partitions in Hive should always be done after the list on
+    // Snowflake. This prevents the edge case where a partition is added
+    // between the Hive and Snowflake list operations.
+    List<Partition> hivePartitions = hmsClient.listPartitions(
+        databaseName, hiveTable.getTableName(), (short) -1 /* all partitions */);
+    Preconditions.checkNotNull(hivePartitions);
+    log.info(String.format("Found %s partitions in Hive.", hivePartitions.size()));
+
+    // Ensure that no file in Snowflake is removed if it's prefixed by any Hive
+    // location, by filtering with a generated regex
+    Pattern hivePartitionRegex = Pattern.compile(String.format("(%s).*",
+        String.join("|",
+                    hivePartitions.stream()
+                        .map(partition -> StringUtil.relativizePartitionURI(
+                            hiveTable, Preconditions.checkNotNull(partition)))
+                        .collect(Collectors.toList()))));
+    List<String> extraPartitions = sfPartLocs.stream()
+        .filter(location -> hivePartitions.isEmpty()
+                            || !hivePartitionRegex.matcher(location).matches())
+        .collect(Collectors.toList());
+
+    // Drop partitions that aren't in Hive
+    log.info(String.format("Dropping %s partition locations",
+                           extraPartitions.size()));
+    SnowflakeClient.generateAndExecuteSnowflakeStatements(
+        new DropPartition(hiveTable, extraPartitions.iterator()),
+        snowflakeConf);
+  }
+
+  /**
+   * Retrieves a set of locations for a Snowflake table that can be used as
+   * an argument to the drop partition command.
+   * @param hiveTable the Hive table
+   * @return a set of partition locations
+   * @throws SQLException Thrown when there was an error executing a Snowflake
+   *                      SQL query (if a Snowflake query must be executed).
+   * @throws IllegalStateException thrown when the file paths from Snowflake
+   *                               are in an unexpected format
+   */
+  private Set<String> getSnowflakePartitionLocations(Table hiveTable)
+      throws SQLException, IllegalStateException
+  {
+    // Get the list of files from Snowflake. Note that this abuses the
+    // behavior of Snowflake's drop partition command to unregister
+    // individual subdirectories instead of actual partitions.
+    ResultSet filePathsResult = SnowflakeClient.executeStatement(
+        String.format(
+            "SELECT FILE_NAME FROM " +
+                "table(information_schema.external_table_files('%s'));",
+            StringUtil.escapeSqlText(hiveTable.getTableName())),
+        snowflakeConf);
+    Preconditions.checkNotNull(filePathsResult);
+    Preconditions.checkState(filePathsResult.getMetaData().getColumnCount() == 1);
+
+    // The relevant paths have the following form:
+    // s3://<bucket>/<padding>/<partition location>/<padding>/<file name>
+    // |- Hive table --------|
+    // |- Hive partitions ------------------------|
+    //                         |- Snowflake partitions -----|
+    //               |- Snowflake files --------------------------------|
+    // To get the Snowflake partitions from the Snowflake files:
+    //  - Append the protocol and bucket
+    //  - Remove the file name
+    //  - Get the path relative to the Hive table
+    String[] hiveTableLocSplit = hiveTable.getSd().getLocation().split("/");
+    Preconditions.checkArgument(hiveTableLocSplit.length > 2);
+    String prefix = String.join("/",
+                                Arrays.asList(hiveTableLocSplit).subList(0, 3));
+
+    List<String> snowflakePartitionLocations = new ArrayList<>();
+    while (filePathsResult.next())
+    {
+      // Note: Must call ResultSet.next() once to move cursor to the first row.
+      //       Also, column indices are 1-based.
+      String filePath = filePathsResult.getString(1);
+
+      Preconditions.checkState(filePath.contains("/"),
+          String.format("No directories to partition on. Path: %s.", filePath));
+
+      String absFilePath = prefix + "/" + filePath.substring(0,
+                                                             filePath.lastIndexOf("/"));
+      Optional<String> partitionLocation = StringUtil.relativizeURI(
+          hiveTable.getSd().getLocation(), absFilePath);
+      Preconditions.checkState(partitionLocation.isPresent(),
+          String.format("Could not relativize %s with %s",
+                        hiveTable.getSd().getLocation(), absFilePath));
+
+      snowflakePartitionLocations.add(partitionLocation.get());
+    }
+    log.info(String.format("Found %s files in Snowflake.", snowflakePartitionLocations.size()));
+
+    return new HashSet<>(snowflakePartitionLocations);
+  }
+}

--- a/src/test/java/HiveSyncToolTest.java
+++ b/src/test/java/HiveSyncToolTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2018 Snowflake Computing Inc. All right reserved.
+ */
+import com.google.common.collect.ImmutableList;
+import com.snowflake.conf.SnowflakeConf;
+import com.snowflake.core.commands.DropPartition;
+import com.snowflake.core.util.HiveSyncTool;
+import com.snowflake.jdbc.client.SnowflakeClient;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+
+/**
+ * Unit tests for the sync tool
+ */
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class,
+                    DriverManager.class, SnowflakeConf.class,
+                    SnowflakeClient.class, HiveSyncTool.class})
+public class HiveSyncToolTest
+{
+  /**
+   * A basic test for the sync tool
+   *
+   * @throws Exception
+   */
+  @Test
+  public void basicSyncTest() throws Exception
+  {
+    // Mock the following via the HiveMetaStoreClient:
+    // db1:
+    //  - tbl1:
+    //     - partition 1
+    //     - partition 2
+    //  - tbl2 (empty)
+    // db2 (empty)
+    HiveMetaStoreClient mockHmsClient = PowerMockito.mock(HiveMetaStoreClient.class);
+    PowerMockito
+        .when(mockHmsClient.getAllDatabases())
+        .thenReturn(ImmutableList.of("db1", "db2"));
+    PowerMockito
+        .when(mockHmsClient.getAllTables("db1"))
+        .thenReturn(ImmutableList.of("tbl1", "tbl2"));
+    PowerMockito
+        .when(mockHmsClient.getAllTables("db2"))
+        .thenReturn(ImmutableList.of());
+
+    // Mock tbl1
+    Table tbl1 = TestUtil.initializeMockTable();
+    PowerMockito
+        .when(mockHmsClient.getTable("db1", "tbl1"))
+        .thenReturn(tbl1);
+    tbl1.setTableName("tbl1");
+    tbl1.setDbName("db1");
+    tbl1.getSd().setLocation("s3://path");
+
+    // Mock tbl2
+    Table tbl2 = TestUtil.initializeMockTable();
+    PowerMockito
+        .when(mockHmsClient.getTable("db1", "tbl2"))
+        .thenReturn(tbl2);
+    tbl2.setTableName("tbl2");
+    tbl2.setDbName("db1");
+    tbl2.getSd().setLocation("s3://path");
+
+    // Mock partitions
+    Partition partition1 = new Partition();
+    partition1.setSd(new StorageDescriptor());
+    partition1.getSd().setLocation("s3://path/to/part1");
+    Partition partition2 = new Partition();
+    partition2.setSd(new StorageDescriptor());
+    partition2.getSd().setLocation("s3://path/to/part2");
+    List<Partition> mockPartitions1 = ImmutableList.of(partition1, partition2);
+    List<Partition> mockPartitions2 = ImmutableList.of();
+    PowerMockito
+        .when(mockHmsClient.listPartitions("db1", "tbl1", (short) -1))
+        .thenReturn(mockPartitions1);
+    PowerMockito
+        .when(mockHmsClient.listPartitions("db1", "tbl2", (short) -1))
+        .thenReturn(mockPartitions2);
+
+    // Mock the following via the SnowflakeClient:
+    // db1:
+    //  - tbl1:
+    //    - partition 2
+    //    - partition 3
+    ResultSet mockResultSet = PowerMockito.mock(ResultSet.class);
+    Mockito.when(mockResultSet.next())
+        .thenReturn(true) // tbl1 has 2 files
+        .thenReturn(true)
+        .thenReturn(false); // tbl2 has no files
+    Mockito.when(mockResultSet.getString(1))
+        .thenReturn("to/part2/file")
+        .thenReturn("to/part3/file");
+    ResultSetMetaData mockMetaData = PowerMockito.mock(ResultSetMetaData.class);
+    Mockito.when(mockMetaData.getColumnCount())
+        .thenReturn(1);
+    Mockito.when(mockResultSet.getMetaData())
+        .thenReturn(mockMetaData);
+    PowerMockito.mockStatic(SnowflakeClient.class);
+    PowerMockito.doReturn(mockResultSet).when(SnowflakeClient.class);
+    SnowflakeClient.executeStatement(any(), any());
+    AtomicInteger numInvocations = new AtomicInteger();
+    PowerMockito.doAnswer((Answer) invocation ->
+    {
+      Object[] args = invocation.getArguments();
+      DropPartition cmd = (DropPartition)args[0];
+      List<String> queries = cmd.generateSqlQueries();
+      if (numInvocations.getAndIncrement() == 0)
+      {
+        assertEquals(1, queries.size());
+        assertEquals("ALTER EXTERNAL TABLE tbl1 DROP PARTITION LOCATION " +
+                         "'to/part3' /* TABLE LOCATION = 's3://path' */;",
+                     queries.get(0));
+      }
+      else
+      {
+        assertEquals(0, queries.size());
+      }
+      return null;
+    }).when(SnowflakeClient.class);
+    SnowflakeClient.generateAndExecuteSnowflakeStatements(any(), any());
+
+    // Run the tool
+    SnowflakeConf mockConfig = TestUtil.initializeMockConfig();
+    PowerMockito
+        .whenNew(SnowflakeConf.class).withAnyArguments().thenReturn(mockConfig);
+    new HiveSyncTool(mockHmsClient).sync();
+
+    // Verify:
+    //  - tables touched
+    //  - partition 3 is dropped from table 1
+    //  - all partitions are touched
+    Mockito
+        .verify(mockHmsClient, Mockito.times(1))
+        .alter_table("db1", "tbl1", tbl1);
+    Mockito
+        .verify(mockHmsClient, Mockito.times(1))
+        .alter_table("db1", "tbl2", tbl2);
+
+    assertEquals(2, numInvocations.get());
+
+    Mockito
+        .verify(mockHmsClient, Mockito.times(2))
+        .alter_partitions(any(), any(), any());
+    Mockito
+        .verify(mockHmsClient)
+        .alter_partitions("db1", "tbl1", mockPartitions1);
+    Mockito
+        .verify(mockHmsClient)
+        .alter_partitions("db1", "tbl2", mockPartitions2);
+  }
+}


### PR DESCRIPTION
Added a tool to do a one-time, one-way sync from Hive to Snowflake.

The tool can be used by creating a simple Java program and invoking it with the Hive classpath, for example:
```
import com.snowflake.core.util.HiveSyncTool;
import org.apache.hadoop.hive.conf.HiveConf;
import org.apache.thrift.TException;
import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;

class Sync
{
  public static void main(String[] args) throws Exception
  {
    new HiveSyncTool(new HiveMetaStoreClient(new HiveConf())).sync();
  }
}
```

To avoid compatibility/configuration issues, we require the user to create a HMS client to use this tool. Unfortunately, this adds a bit of work for users, but I think this is better than having the user run into issues with versions, configs, etc. if we instantiate the client ourselves. An example of such issues are:
 - The constructors of HMS client differ between 2.X & 3.X, so we would need different JARs to avoid runtime exceptions.
 - A call like list_databases might incorrectly return nothing if there's a version mismatch between the client & metastore. We shade our JARs, so this isn't a big deal, but letting the user provide the client allows them to debug this sort of issue.
 - The user doesn't have to worry about configuring the listener to use _their_ Hive configuration. We can remove our dependency on HiveConf.

Requires the following minor changes:
 - new warehouse config (required to query information_schema)
 - refactored DropPartitions to use a list of strings instead of partitions (required to use DropPartitions outside the context of the listener)

This tool depends on possibly unintended behavior, where we allow users to create a partition at location 's3://path', and drop the "partition" at location 's3://path/subpath', which will unregister the files in 's3://path/subpath' but not other files in 's3://path'. Tracking this via SNOW-78555.