### PR TITLE
Added support for key pair authentication to Snowflake

### DIFF
--- a/src/main/java/com/snowflake/conf/SnowflakeConf.java
+++ b/src/main/java/com/snowflake/conf/SnowflakeConf.java
@@ -30,6 +30,9 @@ public class SnowflakeConf extends Configuration
       "The user to use to connect to Snowflake."),
     SNOWFLAKE_JDBC_PASSWORD("snowflake.jdbc.password", "password",
       "The password to use to connect to Snowflake."),
+    SNOWFLAKE_JDBC_PRIVATE_KEY("snowflake.jdbc.privateKey",
+      NOT_A_SF_JDBC_PROPERTY, // The JDBC property is not a string
+      "The private key to use to connect to Snowflake."),
     SNOWFLAKE_JDBC_ACCOUNT("snowflake.jdbc.account", "account",
       "The account to use to connect to Snowflake."),
     SNOWFLAKE_JDBC_ROLE("snowflake.jdbc.role", "role",
@@ -113,6 +116,11 @@ public class SnowflakeConf extends Configuration
     public String getSnowflakePropertyName()
     {
       return this.snowflakePropertyName;
+    }
+
+    public boolean isSnowflakeJDBCProperty()
+    {
+      return this.snowflakePropertyName != NOT_A_SF_JDBC_PROPERTY;
     }
 
     private final String varname;

--- a/src/main/java/com/snowflake/jdbc/client/SnowflakeClient.java
+++ b/src/main/java/com/snowflake/jdbc/client/SnowflakeClient.java
@@ -9,10 +9,17 @@ import com.snowflake.core.commands.Command;
 import com.snowflake.core.util.CommandGenerator;
 import com.snowflake.core.util.Scheduler;
 import com.snowflake.hive.listener.SnowflakeHiveListener;
+import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Base64;
+import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.apache.hadoop.hive.metastore.events.ListenerEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -230,18 +237,36 @@ public class SnowflakeClient
 
         SnowflakeConf.ConfVars confVar =
             SnowflakeConf.ConfVars.findByName(conf.getKey());
-        if (confVar == null)
+        if (!confVar.isSnowflakeJDBCProperty())
         {
-          properties.put(conf.getKey(), conf.getValue());
-        }
-        else
-        {
-          properties.put(confVar.getSnowflakePropertyName(), conf.getValue());
+          return;
         }
 
+        properties.put(confVar.getSnowflakePropertyName(), conf.getValue());
       });
+
     String connectStr = snowflakeConf.get(
         SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_CONNECTION.getVarname());
+
+    String privateKeyConf = snowflakeConf.get(
+        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PRIVATE_KEY.getVarname());
+
+    if (privateKeyConf != null)
+    {
+      try
+      {
+        Security.addProvider(new BouncyCastleProvider());
+        byte[] keyBytes = Base64.decodeBase64(privateKeyConf);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+        properties.put("privateKey", keyFactory.generatePrivate(keySpec));
+      }
+      catch (InvalidKeySpecException | NoSuchAlgorithmException e)
+      {
+        throw new IllegalArgumentException(
+            String.format("Private key is invalid: %s", e), e);
+      }
+    }
 
     return DriverManager.getConnection(connectStr, properties);
   }


### PR DESCRIPTION
This is a minor change, based on: https://github.com/snowflakedb/spark-snowflake/blob/f451dd062d0b11e95b8166fd5181289f93bc9be5/src/main/scala/net/snowflake/spark/snowflake/Parameters.scala

This change is fairly limited, since we'd still need to support encrypted private keys and private keys via the KeyStore. Like other configs, a user would be able to pass this private key via an environment variable.