### PR TITLE
Added Snowflake URI conversions for Azure, GCP

### DIFF
--- a/src/main/java/com/snowflake/core/util/HiveToSnowflakeType.java
+++ b/src/main/java/com/snowflake/core/util/HiveToSnowflakeType.java
@@ -120,20 +120,43 @@ public class HiveToSnowflakeType
   }
 
   /**
-   * converts a Hive URL to a Snowflake URL
+   * Converts a Hive URL to a Snowflake URL. Notably,
+   *  - s3://, s3n://, s3a:// -> s3://
+   *  - wasb[s]://container@account.blob.(endpoint suffix)/...
+   *      -> azure://account.blob.(endpoint suffix)/container/...
+   *      Note: WASB with default storage (i.e. wasbs:///...) is not supported
+   *  - gs:// -> gcs://
    * @param hiveUrl The Hive URL
    * @return The URL as understood by Snowflake
    */
   public static String toSnowflakeURL(String hiveUrl)
   {
-    String snowflakeUrl;
-    // for now, only handle stages on aws
-    // hive can have prefixes 's3n' or 's3a', do some processing for Snowflake
+    int colonIndex = hiveUrl.indexOf(":");
     if (hiveUrl.startsWith("s3"))
     {
-      int colonIndex = hiveUrl.indexOf(":");
-      snowflakeUrl = hiveUrl.substring(0, 2) + hiveUrl.substring(colonIndex);
-      return snowflakeUrl;
+      return "s3" + hiveUrl.substring(colonIndex);
+    }
+
+    if (hiveUrl.startsWith("wasb"))
+    {
+      // Parse out: {schema}://{container}@{account}.{endpoint}/{path}
+      final Pattern wasbUriRegex = Pattern.compile(
+          "[^:]+://([^@]+)@([^.]+)\\.([^/]+)(.*)");
+      Matcher matcher = wasbUriRegex.matcher(hiveUrl);
+      if (matcher.matches())
+      {
+        String container = matcher.group(1);
+        String account = matcher.group(2);
+        String endpointSuffix = matcher.group(3); // prefixed with 'blob.'
+        String path = matcher.group(4); // either empty or prefixed with '/'
+        return String.format("azure://%s.%s/%s%s",
+                             account, endpointSuffix, container, path);
+      }
+    }
+
+    if (hiveUrl.startsWith("gs"))
+    {
+      return "gcs" + hiveUrl.substring(colonIndex);
     }
 
     log.error("Unable to convert URL to Snowflake URL. Skipping conversion: " + hiveUrl);


### PR DESCRIPTION
Snowflake accepts a different scheme in storage locations for different cloud providers. Basically AWS -> s3://, Azure -> azure://, GCP -> gcs://
We only had the conversion for AWS, and this change adds conversions for the other cloud providers.

However, for Azure Storage (aka WASB), we also need to do a bit of rearranging:
Hive provides a form like: 'wasb[s]://containername@accountname.blob.core.windows.net/path'
Snowflake requires a form like: 'azure://myaccount.blob.core.windows.net/mycontainer/load/files'

Note that Azure users can also specify a form like 'wasb:///path', where the default container and storage account is specified elsewhere- support for this form is not in the scope of this PR.

See also:
Azure Storage: https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-use-blob-storage
Snowflake stages on Azure: https://docs.snowflake.net/manuals/user-guide/data-load-azure-create-stage.html
Google Storage: https://cloud.google.com/solutions/using-apache-hive-on-cloud-dataproc