### PR TITLE
Changed package to net.snowflake.hivemetastoreconnector, relocated during shading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
                                 </includes>
                             </artifactSet>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+                                <relocation>
+                                    <pattern>net.snowflake.hivemetastoreconnector</pattern>
+                                    <shadedPattern>net.snowflake.hivemetastoreconnector.internal</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.conf;
+package net.snowflake.hivemetastoreconnector;
 
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeHiveListener.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeHiveListener.java
@@ -1,15 +1,15 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.hive.listener;
+package net.snowflake.hivemetastoreconnector;
 
 import com.google.common.base.Preconditions;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.jdbc.client.SnowflakeClient;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
 import org.apache.hadoop.hive.metastore.api.MetaException;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AddPartition.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AddPartition.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.util.StringUtil;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.util.StringUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.util.HiveToSnowflakeType;
-import com.snowflake.core.util.StringUtil;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.util.HiveToSnowflakeType;
+import net.snowflake.hivemetastoreconnector.util.StringUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/Command.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/Command.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hive.metastore.api.Table;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/CreateExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/CreateExternalTable.java
@@ -1,16 +1,14 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.conf.SnowflakeConf.ConfVars;
-import com.snowflake.core.util.HiveToSnowflakeType;
-import com.snowflake.core.util.HiveToSnowflakeType.SnowflakeFileFormatType;
-import com.snowflake.core.util.StageCredentialUtil;
-import com.snowflake.core.util.StringUtil;
-import com.snowflake.jdbc.client.SnowflakeClient;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.util.HiveToSnowflakeType;
+import net.snowflake.hivemetastoreconnector.util.StageCredentialUtil;
+import net.snowflake.hivemetastoreconnector.util.StringUtil;
+import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -76,8 +74,9 @@ public class CreateExternalTable extends Command
   {
     return String.format(
         "%s__%s", // double underscore
-        StringUtil.escapeSqlIdentifier(snowflakeConf.get(ConfVars.SNOWFLAKE_JDBC_DB.getVarname(),
-                                                         null)),
+        StringUtil.escapeSqlIdentifier(snowflakeConf.get(
+            SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_DB.getVarname(),
+            null)),
         StringUtil.escapeSqlIdentifier(hiveTable.getTableName()));
   }
 
@@ -118,7 +117,7 @@ public class CreateExternalTable extends Command
    */
   public static String generateColumnStr(FieldSchema columnSchema,
                                          int columnPosition,
-                                         SnowflakeFileFormatType snowflakeFileFormatType,
+                                         HiveToSnowflakeType.SnowflakeFileFormatType snowflakeFileFormatType,
                                          SnowflakeConf snowflakeConf)
   {
     String snowflakeType = HiveToSnowflakeType
@@ -128,7 +127,7 @@ public class CreateExternalTable extends Command
     sb.append(" ");
     sb.append(snowflakeType);
     sb.append(" as (VALUE:");
-    if (snowflakeFileFormatType == SnowflakeFileFormatType.CSV)
+    if (snowflakeFileFormatType == HiveToSnowflakeType.SnowflakeFileFormatType.CSV)
     {
       // For CSV, Snowflake populates VALUE with the keys c1, c2, etc. for each
       // column
@@ -141,7 +140,7 @@ public class CreateExternalTable extends Command
       //       user to provide columns with casing that match the data.
       String columnName = columnSchema.getName();
       String casingOverride = snowflakeConf.get(
-          ConfVars.SNOWFLAKE_DATA_COLUMN_CASING.getVarname(), "NONE");
+          SnowflakeConf.ConfVars.SNOWFLAKE_DATA_COLUMN_CASING.getVarname(), "NONE");
       if (casingOverride.equalsIgnoreCase("UPPER"))
       {
         columnName = columnName.toUpperCase();
@@ -210,7 +209,7 @@ public class CreateExternalTable extends Command
     List<FieldSchema> partCols = hiveTable.getPartitionKeys();
 
     // determine the file format type for Snowflake
-    SnowflakeFileFormatType sfFileFmtType =
+    HiveToSnowflakeType.SnowflakeFileFormatType sfFileFmtType =
         HiveToSnowflakeType.toSnowflakeFileFormatType(
           hiveTable.getSd().getSerdeInfo().getSerializationLib(),
           hiveTable.getSd().getInputFormat());
@@ -306,9 +305,9 @@ public class CreateExternalTable extends Command
   {
     String hiveTableLocation = hiveTable.getSd().getLocation();
     String integration = snowflakeConf.get(
-        ConfVars.SNOWFLAKE_INTEGRATION_FOR_HIVE_EXTERNAL_TABLES.getVarname(), null);
+        SnowflakeConf.ConfVars.SNOWFLAKE_INTEGRATION_FOR_HIVE_EXTERNAL_TABLES.getVarname(), null);
     String stage = snowflakeConf.get(
-        ConfVars.SNOWFLAKE_STAGE_FOR_HIVE_EXTERNAL_TABLES.getVarname(), null);
+        SnowflakeConf.ConfVars.SNOWFLAKE_STAGE_FOR_HIVE_EXTERNAL_TABLES.getVarname(), null);
 
     String location;
     String command;
@@ -340,7 +339,7 @@ public class CreateExternalTable extends Command
       command = null;
     }
     else if (snowflakeConf.getBoolean(
-        ConfVars.SNOWFLAKE_ENABLE_CREDENTIALS_FROM_HIVE_CONF.getVarname(), false))
+        SnowflakeConf.ConfVars.SNOWFLAKE_ENABLE_CREDENTIALS_FROM_HIVE_CONF.getVarname(), false))
     {
       // No stage was specified, create one
       location = generateStageName(hiveTable, snowflakeConf);
@@ -348,7 +347,8 @@ public class CreateExternalTable extends Command
           this.canReplace,
           location,
           HiveToSnowflakeType.toSnowflakeURL(hiveTableLocation),
-          StageCredentialUtil.generateCredentialsString(hiveTableLocation, hiveConf));
+          StageCredentialUtil
+              .generateCredentialsString(hiveTableLocation, hiveConf));
     }
     else
     {
@@ -356,7 +356,7 @@ public class CreateExternalTable extends Command
           "Configuration does not specify a stage to use. Add a " +
               "configuration for %s to " +
               "specify the stage.",
-          ConfVars.SNOWFLAKE_STAGE_FOR_HIVE_EXTERNAL_TABLES.getVarname()));
+          SnowflakeConf.ConfVars.SNOWFLAKE_STAGE_FOR_HIVE_EXTERNAL_TABLES.getVarname()));
     }
 
     Preconditions.checkNotNull(location);

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/DropExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/DropExternalTable.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.util.StringUtil;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.util.StringUtil;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.events.DropTableEvent;
 

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/DropPartition.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/DropPartition.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
-import com.snowflake.core.util.StringUtil;
+import net.snowflake.hivemetastoreconnector.util.StringUtil;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.events.DropPartitionEvent;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/LogCommand.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/LogCommand.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.commands;
+package net.snowflake.hivemetastoreconnector.commands;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.snowflake.core.util.StringUtil;
+import net.snowflake.hivemetastoreconnector.util.StringUtil;
 import org.apache.hadoop.hive.metastore.api.Table;
 
 import java.io.PrintWriter;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/core/CommandGenerator.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/core/CommandGenerator.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.util;
+package net.snowflake.hivemetastoreconnector.core;
 
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.commands.AddPartition;
-import com.snowflake.core.commands.AlterExternalTable;
-import com.snowflake.core.commands.Command;
-import com.snowflake.core.commands.CreateExternalTable;
-import com.snowflake.core.commands.DropExternalTable;
-import com.snowflake.core.commands.DropPartition;
-import com.snowflake.hive.listener.SnowflakeHiveListener;
+import net.snowflake.hivemetastoreconnector.commands.AddPartition;
+import net.snowflake.hivemetastoreconnector.commands.AlterExternalTable;
+import net.snowflake.hivemetastoreconnector.commands.Command;
+import net.snowflake.hivemetastoreconnector.commands.CreateExternalTable;
+import net.snowflake.hivemetastoreconnector.commands.DropExternalTable;
+import net.snowflake.hivemetastoreconnector.commands.DropPartition;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.SnowflakeHiveListener;
 import org.apache.hadoop.hive.metastore.events.AddPartitionEvent;
 import org.apache.hadoop.hive.metastore.events.AlterPartitionEvent;
 import org.apache.hadoop.hive.metastore.events.AlterTableEvent;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/core/Scheduler.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/core/Scheduler.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.util;
+package net.snowflake.hivemetastoreconnector.core;
 
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
@@ -9,11 +9,10 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.collect.Lists;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.commands.AddPartition;
-import com.snowflake.core.commands.Command;
-import com.snowflake.hive.listener.SnowflakeHiveListener;
-import com.snowflake.jdbc.client.SnowflakeClient;
+import net.snowflake.hivemetastoreconnector.commands.AddPartition;
+import net.snowflake.hivemetastoreconnector.commands.Command;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.SnowflakeHiveListener;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
@@ -1,14 +1,12 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.jdbc.client;
+package net.snowflake.hivemetastoreconnector.core;
 
 import com.google.common.base.Preconditions;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.commands.Command;
-import com.snowflake.core.util.CommandGenerator;
-import com.snowflake.core.util.Scheduler;
-import com.snowflake.hive.listener.SnowflakeHiveListener;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.SnowflakeHiveListener;
+import net.snowflake.hivemetastoreconnector.commands.Command;
 import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Base64;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.apache.hadoop.hive.metastore.events.ListenerEvent;
@@ -218,7 +216,8 @@ public class SnowflakeClient
   {
     try
     {
-      Class.forName("com.snowflake.jdbc.client.SnowflakeClient");
+      Class.forName(
+          "net.snowflake.hivemetastoreconnector.SnowflakeClient");
     }
     catch(ClassNotFoundException e)
     {

--- a/src/main/java/net/snowflake/hivemetastoreconnector/util/HiveToSnowflakeType.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/util/HiveToSnowflakeType.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.util;
+package net.snowflake.hivemetastoreconnector.util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/net/snowflake/hivemetastoreconnector/util/StageCredentialUtil.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/util/StageCredentialUtil.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.util;
+package net.snowflake.hivemetastoreconnector.util;
 
 import org.apache.hadoop.conf.Configuration;
 

--- a/src/main/java/net/snowflake/hivemetastoreconnector/util/StringUtil.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/util/StringUtil.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-package com.snowflake.core.util;
+package net.snowflake.hivemetastoreconnector.util;
 
 import java.net.URI;
 import java.util.Optional;

--- a/src/test/java/AddPartitionTest.java
+++ b/src/test/java/AddPartitionTest.java
@@ -2,9 +2,8 @@
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.commands.AddPartition;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.commands.AddPartition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.api.Partition;

--- a/src/test/java/AlterExternalTableTest.java
+++ b/src/test/java/AlterExternalTableTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-import com.snowflake.core.commands.AlterExternalTable;
+import net.snowflake.hivemetastoreconnector.commands.AlterExternalTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;

--- a/src/test/java/CreateTableTest.java
+++ b/src/test/java/CreateTableTest.java
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.core.commands.CreateExternalTable;
-import com.snowflake.jdbc.client.SnowflakeClient;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.commands.CreateExternalTable;
+import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;

--- a/src/test/java/DropPartitionTest.java
+++ b/src/test/java/DropPartitionTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-import com.snowflake.core.commands.DropPartition;
+import net.snowflake.hivemetastoreconnector.commands.DropPartition;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;

--- a/src/test/java/DropTableTest.java
+++ b/src/test/java/DropTableTest.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-import com.snowflake.core.commands.DropExternalTable;
+import net.snowflake.hivemetastoreconnector.commands.DropExternalTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.api.Table;

--- a/src/test/java/SnowflakeHiveListenerTests.java
+++ b/src/test/java/SnowflakeHiveListenerTests.java
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.hive.listener.SnowflakeHiveListener;
-import com.snowflake.jdbc.client.SnowflakeClient;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.SnowflakeHiveListener;
+import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.api.Table;

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
-import com.snowflake.conf.SnowflakeConf;
-import com.snowflake.jdbc.client.SnowflakeClient;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;


### PR DESCRIPTION
See title. This change will prevent future namespace collisions.

There are 3 changes:
1. change package from 'com.snowflake...' to 'net.snowflake.hivemetastoreconnector...'
2. change the directory structure to reflect this
3. add package relocation during shading, from 'net.snowflake.hivemetastoreconnector' to 'net.snowflake.hivemetastoreconnector.internal'. This is the same convention used by https://github.com/snowflakedb/snowflake-ingest-java/blob/master/pom.xml, https://github.com/snowflakedb/snowflake-jdbc/blob/master/pom.xml.

This was done via IDE.