### PR TITLE
Minor changes to pom.xml and javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     </licenses>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -39,6 +40,32 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,18 @@
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!-- disable default maven deploy plugin since we are using gpg:sign-and-deploy-file -->
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencies>

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AddPartition.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AddPartition.java
@@ -182,7 +182,7 @@ public class AddPartition extends Command
   /**
    * Combines N add partition commands with M total partitions into
    * ceil(M / MAX_ADDED_PARTITIONS) new add partition commands. If
-   * M > N * MAX_ADDED_PARTITIONS, then the result will be more than N elements.
+   * M &gt; N * MAX_ADDED_PARTITIONS, then the result will be more than N elements.
    * Each command except the last one will have MAX_ADDED_PARTITIONS partitions.
    * Assumes that the commands are all for the same table, with no
    * modifications to the table in between


### PR DESCRIPTION
Trivial changes. Our jar requires javadocs and sources to be released. There was a minor javadoc compilation error involving a '>' symbol.