### PR TITLE
Fixed relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <relocations>
                                 <relocation>
-                                    <pattern>net.snowflake.hivemetastoreconnector</pattern>
-                                    <shadedPattern>net.snowflake.hivemetastoreconnector.internal</shadedPattern>
+                                    <pattern>net.snowflake.client.jdbc</pattern>
+                                    <shadedPattern>net.snowflake.hivemetastoreconnector.internal.jdbc</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
There was an issue with https://github.com/snowflakedb/snowflake-hive-metastore-connector/pull/23 where the wrong classes were relocated. This is a trivial change.