### PR TITLE
Changes for TravisCI unit tests and code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: java
+matrix:
+  include:
+    - jdk: openjdk8
+
+env:
+  - JACOCO_COVERAGE=true
+
+script:
+  - "./scripts/run_travis.sh"
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <jacoco.skip.instrument>true</jacoco.skip.instrument>
+    </properties>
+
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -64,33 +68,6 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>net.snowflake:snowflake-jdbc:*</include>
-                                </includes>
-                            </artifactSet>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <relocations>
-                                <relocation>
-                                    <pattern>net.snowflake.client.jdbc</pattern>
-                                    <shadedPattern>net.snowflake.hivemetastoreconnector.internal.jdbc</shadedPattern>
-                                </relocation>
-                            </relocations>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -141,10 +118,57 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.21.0-GA</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+            <version>0.8.1</version>
         </dependency>
     </dependencies>
 
     <profiles>
+        <profile>
+            <id>shadeDep</id>
+            <activation>
+                <property>
+                    <name>!not-shadeDep</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.1</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactSet>
+                                        <includes>
+                                            <include>net.snowflake:snowflake-jdbc:*</include>
+                                        </includes>
+                                    </artifactSet>
+                                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>net.snowflake.client.jdbc</pattern>
+                                            <shadedPattern>net.snowflake.hivemetastoreconnector.internal.jdbc</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>ossrh-deploy</id>
             <activation>
@@ -176,6 +200,71 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>travis</id>
+            <activation>
+                <property>
+                    <name>travis</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <executions>
+                            <execution>
+                                <id>default-test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jacoco-agent.destfile>target/jacoco-ut.exec</jacoco-agent.destfile>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.1</version>
+                        <executions>
+                            <!-- Offline instrumentation due to Powermock -->
+                            <execution>
+                                <id>default-instrument</id>
+                                <goals>
+                                    <goal>instrument</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-restore-instrumented-classes</id>
+                                <goals>
+                                    <goal>restore-instrumented-classes</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-report</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <dataFile>target/jacoco-ut.exec</dataFile>
+                                    <outputDirectory>target/jacoco-ut</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>${jacoco.skip.instrument}</skip>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/scripts/run_travis.sh
+++ b/scripts/run_travis.sh
@@ -1,0 +1,11 @@
+mvn install -DskipTests=true --batch-mode --show-version
+
+PARAMS=()
+PARAMS+=("-Dtravis")
+# testing will not need shade dep. otherwise codecov cannot work
+PARAMS+=("-Dnot-shadeDep")
+echo "JDK Version: $TRAVIS_JDK_VERSION"
+[[ -n "$JACOCO_COVERAGE" ]] && PARAMS+=("-Djacoco.skip.instrument=false")
+# verify phase is after test/integration-test phase, which means both unit test
+# and integration test will be run
+mvn "${PARAMS[@]}" verify --batch-mode

--- a/src/test/java/CreateTableTest.java
+++ b/src/test/java/CreateTableTest.java
@@ -638,7 +638,7 @@ public class CreateTableTest
 
     PowerMockito.mockStatic(DriverManager.class);
     PowerMockito
-        .when(DriverManager.getConnection(any(String.class),
+        .when(DriverManager.getConnection(any(),
                                           any(Properties.class)))
         .thenReturn(mockConnection);
 
@@ -648,6 +648,10 @@ public class CreateTableTest
     // Execute an event
     SnowflakeClient.createAndExecuteCommandForSnowflake(
         createTableEvent, mockConfig);
+
+    PowerMockito.verifyStatic();
+    DriverManager.getConnection(any(),
+                                any(Properties.class));
 
     // Count the number of times each query was executed. They should have
     // executed twice each.
@@ -793,7 +797,7 @@ public class CreateTableTest
         .verify(mockHiveConfig, Mockito.times(0))
         .get(any());
     Mockito
-        .verify(mockHiveConfig, Mockito.times(0));
+        .verifyZeroInteractions(mockHiveConfig);
   }
 
   /**
@@ -844,7 +848,7 @@ public class CreateTableTest
         createTableEvent, mockConfig);
 
     Mockito
-        .verify(mockStatement, Mockito.times(0)); // No retries
+        .verifyZeroInteractions(mockStatement); // No retries
     assertEquals(0, executeQueryParams.size());
   }
 }


### PR DESCRIPTION
This contains the following changes:
 - a travis.yml file to configure Travis to run run_travis.sh, which runs tests and code coverage
 - pom.xml changes for the new Travis build. We use Powermock, so our jacoco configuration will look a little different than in https://github.com/snowflakedb/snowflake-ingest-java/blob/master/pom.xml
 - random minor changes to a unit test, which was causing issues with the Travis build

I've been testing the build stability in my own fork:
 - Travis build: https://travis-ci.com/wwong-snow/snowflake-hive-metastore-connector/
 - sample code coverage report: https://codecov.io/gh/wwong-snow/snowflake-hive-metastore-connector/commit/b26fea76cd28b9391ef9785010b6e0726d33de8e