### PR TITLE
Added support for reading credentials from credential provider API

### DIFF
--- a/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
@@ -138,6 +138,34 @@ public class SnowflakeConf extends Configuration
 
   private static URL snowflakeConfigUrl;
 
+  /**
+   * Convenience method. Retrieves a secret from a credential provider,
+   * configuration, or default value in the respective order of preference.
+   * @param name the name of the configuration
+   * @param defaultValue the default value of the secret, if any
+   * @return the secret
+   */
+  public String getSecret(String name, String defaultValue)
+  {
+    try
+    {
+      char[] secret = getPasswordFromCredentialProviders(name);
+      if (secret != null)
+      {
+        return String.valueOf(secret);
+      }
+    }
+    catch (Throwable t)
+    {
+      log.warn(String.format("Error reading secret named %s, falling back " +
+                                 "to configuration or default. Error: %s",
+                             name, t));
+      // Fallback to configuration
+    }
+
+    return get(name, defaultValue);
+  }
+
   static
   {
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
@@ -142,10 +142,9 @@ public class SnowflakeConf extends Configuration
    * Convenience method. Retrieves a secret from a credential provider,
    * configuration, or default value in the respective order of preference.
    * @param name the name of the configuration
-   * @param defaultValue the default value of the secret, if any
    * @return the secret
    */
-  public String getSecret(String name, String defaultValue)
+  public String getSecret(String name)
   {
     try
     {
@@ -163,7 +162,7 @@ public class SnowflakeConf extends Configuration
       // Fallback to configuration
     }
 
-    return get(name, defaultValue);
+    return get(name, null);
   }
 
   static

--- a/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
@@ -244,8 +244,7 @@ public class SnowflakeClient
 
     // JDBC password
     String snowflakePassword = snowflakeConf.getSecret(
-        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PASSWORD.getVarname(),
-        null);
+        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PASSWORD.getVarname());
     if (snowflakePassword != null)
     {
       properties.put(SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PASSWORD.getSnowflakePropertyName(),
@@ -254,8 +253,7 @@ public class SnowflakeClient
 
     // JDBC private key
     String privateKeyConf = snowflakeConf.getSecret(
-        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PRIVATE_KEY.getVarname(),
-        null);
+        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PRIVATE_KEY.getVarname());
     if (privateKeyConf != null)
     {
       try

--- a/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
@@ -242,12 +242,20 @@ public class SnowflakeClient
         properties.put(confVar.getSnowflakePropertyName(), conf.getValue());
       });
 
-    String connectStr = snowflakeConf.get(
-        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_CONNECTION.getVarname());
+    // JDBC password
+    String snowflakePassword = snowflakeConf.getSecret(
+        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PASSWORD.getVarname(),
+        null);
+    if (snowflakePassword != null)
+    {
+      properties.put(SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PASSWORD.getSnowflakePropertyName(),
+                     snowflakePassword);
+    }
 
-    String privateKeyConf = snowflakeConf.get(
-        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PRIVATE_KEY.getVarname());
-
+    // JDBC private key
+    String privateKeyConf = snowflakeConf.getSecret(
+        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_PRIVATE_KEY.getVarname(),
+        null);
     if (privateKeyConf != null)
     {
       try
@@ -266,6 +274,9 @@ public class SnowflakeClient
     }
 
     properties.put(SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_SCHEMA.getSnowflakePropertyName(), schema);
+    
+    String connectStr = snowflakeConf.get(
+        SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_CONNECTION.getVarname());
 
     return DriverManager.getConnection(connectStr, properties);
   }


### PR DESCRIPTION
With this change, users wouldn't have to manage their passwords via environment variables or system properties, they can just use the credential provider API. Examples on usage are here: https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/CredentialProviderAPI.html