### PR TITLE
Multiple Hive Metastore DB support for connector

### DIFF
--- a/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/SnowflakeConf.java
@@ -42,11 +42,17 @@ public class SnowflakeConf extends Configuration
     SNOWFLAKE_JDBC_WAREHOUSE("snowflake.jdbc.warehouse", "warehouse",
       "The warehouse to use with Snowflake, if necessary."),
     SNOWFLAKE_JDBC_SCHEMA("snowflake.jdbc.schema", "schema",
-      "The schema to use to connect to Snowflake."),
+      "The default schema to use to connect to Snowflake."),
     SNOWFLAKE_JDBC_SSL("snowflake.jdbc.ssl", "ssl",
       "Use ssl to connect to Snowflake"),
     SNOWFLAKE_JDBC_CONNECTION("snowflake.jdbc.connection", "connection",
       "The Snowflake connection string."),
+    SNOWFLAKE_SCHEMA_LIST(
+            "snowflake.hive-metastore-listener.schemas", NOT_A_SF_JDBC_PROPERTY,
+            "A list of comma separated schemas, where each schema should be the " +
+                    "name of a Hive schema (database) that should be synced to the corresponding " +
+                    "Snowflake schema. If a hive schema is not listed here, the connector will " +
+                    "default to syncing that schema to the snowflake.jdbc.schema property."),
     SNOWFLAKE_STAGE_FOR_HIVE_EXTERNAL_TABLES(
         "snowflake.hive-metastore-listener.stage", NOT_A_SF_JDBC_PROPERTY,
         "The stage to use when creating external tables with Snowflake"),

--- a/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/core/SnowflakeClient.java
@@ -23,8 +23,11 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Class that uses the snowflake jdbc to connect to snowflake.
@@ -84,8 +87,20 @@ public class SnowflakeClient
     List<String> commandList;
     try
     {
+      log.info("Checking if " + command.getDatabaseName() + " is in the configured schema list.");
+      Set<String> schemaSet = new HashSet<>(snowflakeConf.getStringCollection(
+              SnowflakeConf.ConfVars.SNOWFLAKE_SCHEMA_LIST.getVarname())
+              .stream().map(String::toLowerCase).collect(Collectors.toSet()));
+      String defaultSchema = snowflakeConf.get(
+              SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_SCHEMA.getVarname());
+      String schema;
+      if (schemaSet.contains(command.getDatabaseName().toLowerCase())) {
+        schema = command.getDatabaseName();
+      } else {
+        schema = defaultSchema;
+      }
       commandList = command.generateSqlQueries();
-      executeStatements(commandList, snowflakeConf);
+      executeStatements(commandList, snowflakeConf, schema);
     }
     catch (Exception e)
     {
@@ -98,16 +113,18 @@ public class SnowflakeClient
    * @param commandList - The list of queries to execute
    * @param snowflakeConf - the configuration for Snowflake Hive metastore
    *                        listener
+   * @param schema - the schema to use for the jdbc connection
    */
   public static void executeStatements(List<String> commandList,
-                                       SnowflakeConf snowflakeConf)
+                                       SnowflakeConf snowflakeConf,
+                                       String schema)
   {
     log.info("Executing statements: " + String.join(", ", commandList));
 
     // Get connection
     log.info("Getting connection to the Snowflake");
     try (Connection connection = retry(
-        () -> getConnection(snowflakeConf), snowflakeConf))
+        () -> getConnection(snowflakeConf, schema), snowflakeConf))
     {
       commandList.forEach(commandStr ->
       {
@@ -157,15 +174,17 @@ public class SnowflakeClient
    * @param commandStr - The query to execute
    * @param snowflakeConf - the configuration for Snowflake Hive metastore
    *                        listener
+   * @param schema - the schema to use for the jdbc connection
    * @return The result of the executed query
    * @throws SQLException Thrown if there was an error executing the
    *                      statement or forming a connection.
    */
   public static ResultSet executeStatement(String commandStr,
-                                           SnowflakeConf snowflakeConf)
+                                           SnowflakeConf snowflakeConf,
+                                           String schema)
       throws SQLException
   {
-    try (Connection connection = retry(() -> getConnection(snowflakeConf),
+    try (Connection connection = retry(() -> getConnection(snowflakeConf, schema),
                                        snowflakeConf);
         Statement statement = retry(connection::createStatement,
                                     snowflakeConf))
@@ -208,10 +227,11 @@ public class SnowflakeClient
    * given properties.
    * @param snowflakeConf - the configuration for Snowflake Hive metastore
    *                        listener
+   * @param schema - the schema to use for the connection
    * @return The JDBC connection
    * @throws SQLException Exception thrown when initializing the connection
    */
-  private static Connection getConnection(SnowflakeConf snowflakeConf)
+  private static Connection getConnection(SnowflakeConf snowflakeConf, String schema)
       throws SQLException
   {
     try
@@ -265,6 +285,8 @@ public class SnowflakeClient
             String.format("Private key is invalid: %s", e), e);
       }
     }
+
+    properties.put(SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_SCHEMA.getSnowflakePropertyName(), schema);
 
     return DriverManager.getConnection(connectStr, properties);
   }

--- a/src/main/java/net/snowflake/hivemetastoreconnector/util/HiveToSnowflakeSchema.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/util/HiveToSnowflakeSchema.java
@@ -1,0 +1,55 @@
+package net.snowflake.hivemetastoreconnector.util;
+
+import com.google.common.base.Preconditions;
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A util to get the correct Snowflake schema from the Hive schema.
+ */
+public class HiveToSnowflakeSchema {
+    private static final Logger log = LoggerFactory.getLogger(
+            HiveToSnowflakeSchema.class);
+
+    public static String getSnowflakeDefaultSchema(SnowflakeConf snowflakeConf) {
+        return snowflakeConf.get(SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_SCHEMA.getVarname());
+    }
+
+    public static Set<String> getSnowflakeSchemaSet(SnowflakeConf snowflakeConf) {
+        return new HashSet<>(snowflakeConf.getStringCollection(
+                SnowflakeConf.ConfVars.SNOWFLAKE_SCHEMA_LIST.getVarname())
+                .stream().map(String::toLowerCase).collect(Collectors.toSet()));
+    }
+
+    public static String getSnowflakeSchemaFromHiveSchema(
+        String hiveSchema,
+        String snowflakeDefaultSchema,
+        Set<String> snowflakeSchemaSet) {
+        Preconditions.checkNotNull(
+             snowflakeDefaultSchema,
+            "Could not find default Snowflake schema. " +
+             "Ensure snowflake-config.xml, contains the " +
+             "snowflake.jdbc.schema property.");
+
+        if (snowflakeSchemaSet.contains(hiveSchema.toLowerCase())) {
+            log.info(hiveSchema + " is in the configured schema list.");
+            return hiveSchema;
+        } else {
+            log.info(hiveSchema + " is not in the configured schema list. " +
+                    "Use default schema:" + snowflakeDefaultSchema);
+            return snowflakeDefaultSchema;
+        }
+    }
+
+    public static String getSnowflakeSchemaFromHiveSchema(String hiveSchema, SnowflakeConf snowflakeConf) {
+        return getSnowflakeSchemaFromHiveSchema(
+                hiveSchema,
+                getSnowflakeDefaultSchema(snowflakeConf),
+                getSnowflakeSchemaSet(snowflakeConf));
+    }
+}

--- a/src/test/java/CreateTableTest.java
+++ b/src/test/java/CreateTableTest.java
@@ -361,7 +361,7 @@ public class CreateTableTest
         .thenReturn("aStage");
 
     // Mock Snowflake client to return a location for this stage
-    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path");
+    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path", table.getDbName());
 
     CreateTableEvent createTableEvent =
         new CreateTableEvent(table, true, TestUtil.initializeMockHMSHandler());
@@ -389,7 +389,7 @@ public class CreateTableTest
        new CreateExternalTable(createTableEvent, mockConfig);
 
     // Mock Snowflake client to return a location for this stage
-    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path");
+    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path", "someSchema1");
 
     commands = createExternalTable.generateSqlQueries();
     assertEquals("generated create stage command does not match " +
@@ -421,7 +421,7 @@ public class CreateTableTest
         .thenReturn("aStage");
 
     // Mock Snowflake client to return a location for this stage
-    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path/to/table");
+    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path/to/table", table.getDbName());
 
     CreateTableEvent createTableEvent =
         new CreateTableEvent(table, true, TestUtil.initializeMockHMSHandler());
@@ -459,7 +459,7 @@ public class CreateTableTest
         .thenReturn("aStage");
 
     // Mock Snowflake client to return a location for this stage
-    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname2");
+    TestUtil.mockSnowflakeStageWithLocation("s3://bucketname2", table.getDbName());
 
     CreateTableEvent createTableEvent =
         new CreateTableEvent(table, true, TestUtil.initializeMockHMSHandler());

--- a/src/test/java/CreateTableTest.java
+++ b/src/test/java/CreateTableTest.java
@@ -370,8 +370,8 @@ public class CreateTableTest
         new CreateExternalTable(createTableEvent, mockConfig);
 
     List<String> commands = createExternalTable.generateSqlQueries();
-    assertEquals("generated create stage command does not match " +
-                     "expected create stage command",
+    assertEquals("generated create external table command does not match " +
+                    "expected create external table command",
                  "CREATE OR REPLACE EXTERNAL TABLE t1(partcol INT as " +
                      "(parse_json(metadata$external_table_partition):PARTCOL::INT)," +
                      "name STRING as (parse_json(metadata$external_table_partition):NAME::STRING))" +
@@ -392,8 +392,8 @@ public class CreateTableTest
     TestUtil.mockSnowflakeStageWithLocation("s3://bucketname/path", "someSchema1");
 
     commands = createExternalTable.generateSqlQueries();
-    assertEquals("generated create stage command does not match " +
-                     "expected create stage command",
+    assertEquals("generated create external table command does not match " +
+                     "expected create external table command",
                  "CREATE OR REPLACE EXTERNAL TABLE t1(partcol INT as " +
                      "(parse_json(metadata$external_table_partition):PARTCOL::INT)," +
                      "name STRING as (parse_json(metadata$external_table_partition):NAME::STRING))" +

--- a/src/test/java/HiveSyncToolTest.java
+++ b/src/test/java/HiveSyncToolTest.java
@@ -125,7 +125,7 @@ public class HiveSyncToolTest
         .thenReturn(mockMetaData);
     PowerMockito.mockStatic(SnowflakeClient.class);
     PowerMockito.doReturn(mockResultSet).when(SnowflakeClient.class);
-    SnowflakeClient.executeStatement(any(), any());
+    SnowflakeClient.executeStatement(any(), any(), any());
     List<List<String>> invocations = new ArrayList<>();
     PowerMockito.doAnswer((Answer) invocation ->
     {

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
 
 import javax.sql.RowSet;
@@ -113,7 +114,7 @@ public class TestUtil
    * @param stageLocation The location that should be returned by the Snowflake
    *                      client.
    */
-  public static void mockSnowflakeStageWithLocation(String stageLocation)
+  public static void mockSnowflakeStageWithLocation(String stageLocation, String expectedSchema)
       throws Exception
   {
     ResultSetMetaData mockMetadata = PowerMockito.mock(ResultSetMetaData.class);
@@ -134,7 +135,7 @@ public class TestUtil
     PowerMockito // Note: clobbers mocks for SnowflakeClient.executeStatement
         .when(SnowflakeClient.executeStatement(anyString(),
                                                any(SnowflakeConf.class),
-                                               anyString()))
+                                               Matchers.eq(expectedSchema)))
         .thenReturn(mockRowSet);
   }
 }

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -36,6 +36,10 @@ public class TestUtil
         .thenReturn("accessKeyId");
     PowerMockito.when(mockConfig.get("fs.s3n.awsSecretAccessKey"))
         .thenReturn("awsSecretKey");
+    PowerMockito.when(mockConfig.get("snowflake.jdbc.schema"))
+        .thenReturn("someSchema");
+    PowerMockito.when(mockConfig.getStringCollection("snowflake.hive-metastore-listener.schemas"))
+          .thenReturn(Arrays.asList(new String[]{"someDb", "someSchema2", "DB1"}));
     PowerMockito.when(mockHandler.getConf()).thenReturn(mockConfig);
 
     return mockHandler;
@@ -51,6 +55,9 @@ public class TestUtil
     PowerMockito
         .when(mockConfig.get("snowflake.jdbc.db", null))
         .thenReturn("someDB");
+    PowerMockito
+        .when(mockConfig.get("snowflake.jdbc.schema"))
+        .thenReturn("someSchema1");
     PowerMockito
         .when(mockConfig.getBoolean("snowflake.hive-metastore-listener.enable-creds-from-conf", false))
         .thenReturn(true);
@@ -69,6 +76,9 @@ public class TestUtil
     PowerMockito
         .when(mockConfig.get("snowflake.hive-metastore-listener.data-column-casing", "NONE"))
         .thenReturn("NONE");
+    PowerMockito
+        .when(mockConfig.getStringCollection("snowflake.hive-metastore-listener.schemas"))
+        .thenReturn(Arrays.asList(new String[]{"someDb", "someSchema2", "DB1"}));
     return mockConfig;
   }
 
@@ -123,7 +133,8 @@ public class TestUtil
     PowerMockito.mockStatic(SnowflakeClient.class);
     PowerMockito // Note: clobbers mocks for SnowflakeClient.executeStatement
         .when(SnowflakeClient.executeStatement(anyString(),
-                                               any(SnowflakeConf.class)))
+                                               any(SnowflakeConf.class),
+                                               anyString()))
         .thenReturn(mockRowSet);
   }
 }


### PR DESCRIPTION
One of the limitations of hive connector is that it syncs Hive databases to a single database / single schema on Snowflake. This can cause name conflicts and lead to confusing behavior when there are multiple tables with the same name in different hive databases.

With this change, we are introducing a new configuration property: SNOWFLAKE_SCHEMA_LIST. This property accepts a list of strings, separated by commas. The connector will then try to find the appropriate schema for the hive table and create an external table in that schema. This is done by case-insensitive matching of the name of the Hive Schema/DB to one of the names in the schema list. If there is no match found, we default to using the schema specified in the SNOWFLAKE_JDBC_SCHEMA property.

The connector assumes that any schema listed in the property already exists on Snowflake. 
If the SNOWFLAKE_STAGE_FOR_HIVE_EXTERNAL_TABLES property is specified, it must exist on all the schemas listed in SNOWFLAKE_SCHEMA_LIST. Similarly for SNOWFLAKE_INTEGRATION_FOR_HIVE_EXTERNAL_TABLES.