### PR TITLE
SNOW-164866 Update JDBC version used by the connector.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.6.21</version>
+            <version>3.12.11</version>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
  */
+import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.hivemetastoreconnector.SnowflakeConf;
 import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
@@ -13,6 +14,7 @@ import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
 
 import javax.sql.RowSet;
+import java.sql.Connection;
 import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,9 +135,12 @@ public class TestUtil
     PowerMockito.when(mockRowSet.getMetaData()).thenReturn(mockMetadata);
     PowerMockito.mockStatic(SnowflakeClient.class);
     PowerMockito // Note: clobbers mocks for SnowflakeClient.executeStatement
-        .when(SnowflakeClient.executeStatement(anyString(),
-                                               any(SnowflakeConf.class),
-                                               Matchers.eq(expectedSchema)))
+        .when(SnowflakeClient.executeStatement(any(Connection.class),
+                                               anyString(),
+                                               any(SnowflakeConf.class)))
         .thenReturn(mockRowSet);
+    PowerMockito
+            .when(SnowflakeClient.getConnection(any(SnowflakeConf.class), Matchers.eq(expectedSchema)))
+            .thenReturn(PowerMockito.mock(SnowflakeConnectionV1.class));
   }
 }


### PR DESCRIPTION
Some code changes were required because currently in the connector we close the connection and statement (which in turn closes the result set) before parsing the result set. With the new driver version, this causes an exception to be thrown.

With this change, we do all the processing of the result set while the connection is open.