### PR TITLE
Update Hive Metastore to v3.1.3 and related changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-hive-metastore-connector</artifactId>
-    <version>0.5.1</version>
+    <version>0.6.0</version>
 
     <developers>
         <developer>
@@ -102,12 +102,12 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
-            <version>2.3.5</version>
+            <version>3.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.7</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>net.snowflake</groupId>
@@ -117,13 +117,13 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>1.5.6</version>
+            <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>1.5.6</version>
+            <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -139,6 +139,16 @@
             <scope>test</scope>
             <version>0.8.1</version>
         </dependency>
+        <dependency>
+    	    <groupId>org.apache.hadoop</groupId>
+    	    <artifactId>hadoop-mapreduce-client-core</artifactId>
+    	    <version>3.1.4</version>
+	</dependency>
+	<dependency>
+    	    <groupId>org.apache.hadoop</groupId>
+    	    <artifactId>hadoop-mapred</artifactId>
+    	    <version>0.22.0</version>
+	</dependency>
     </dependencies>
 
     <profiles>

--- a/src/test/java/AddPartitionTest.java
+++ b/src/test/java/AddPartitionTest.java
@@ -6,6 +6,7 @@ import net.snowflake.hivemetastoreconnector.SnowflakeConf;
 import net.snowflake.hivemetastoreconnector.commands.AddPartition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -50,7 +51,7 @@ public class AddPartitionTest
     partition.setSd(new StorageDescriptor());
     partition.getSd().setLocation("s3n://bucketname/path/to/table/sub/path");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     AddPartitionEvent addPartitionEvent =
         new AddPartitionEvent(table, partition, true, mockHandler);
@@ -88,7 +89,7 @@ public class AddPartitionTest
     partition2.setSd(new StorageDescriptor());
     partition2.getSd().setLocation("s3n://bucketname/path/to/table/sub/path2");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     AddPartitionEvent addPartitionEvent = new AddPartitionEvent(
       table, Arrays.asList(partition1, partition2), true, mockHandler);
@@ -128,7 +129,7 @@ public class AddPartitionTest
     partition2.setSd(new StorageDescriptor());
     partition2.getSd().setLocation("s3n://bucketname/path/to/table/sub/path2");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     AddPartitionEvent addPartitionEvent1 = new AddPartitionEvent(
         table, Collections.singletonList(partition1), true, mockHandler);
@@ -174,7 +175,7 @@ public class AddPartitionTest
     partition2.setSd(new StorageDescriptor());
     partition2.getSd().setLocation("s3n://bucketname/path/to/table/sub/path2");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     AddPartitionEvent addPartitionEvent1 = new AddPartitionEvent(
         table, Collections.singletonList(partition1), true, mockHandler);
@@ -236,7 +237,7 @@ public class AddPartitionTest
     partition.setSd(new StorageDescriptor());
     partition.getSd().setLocation("s3n://bucketname/path/to/table/sub/path");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     AddPartitionEvent addPartitionEvent =
         new AddPartitionEvent(table, partition, true, mockHandler);
@@ -274,7 +275,7 @@ public class AddPartitionTest
 
     List<Partition> partitions = ImmutableList.of(partition1, partition2);
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     AddPartitionEvent addPartitionEvent =
         new AddPartitionEvent(table, partitions, true, mockHandler);

--- a/src/test/java/AlterExternalTableTest.java
+++ b/src/test/java/AlterExternalTableTest.java
@@ -4,6 +4,7 @@
 import net.snowflake.hivemetastoreconnector.commands.AlterExternalTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.events.AlterTableEvent;
@@ -35,9 +36,9 @@ public class AlterExternalTableTest
   public void basicTouchTableGenerateCommandTest() throws Exception
   {
     Table table = TestUtil.initializeMockTable();
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     AlterTableEvent alterTableEvent = new AlterTableEvent(table, table,
-                                                          true, mockHandler);
+                                                          true, true, mockHandler);
 
     AlterExternalTable alterTable = new AlterExternalTable(alterTableEvent, TestUtil.initializeMockConfig());
 
@@ -75,9 +76,9 @@ public class AlterExternalTableTest
     table.getSd().setCols(Arrays.asList(
         new FieldSchema("col1", "int", null),
         new FieldSchema("col2", "string", null)));
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     AlterTableEvent alterTableEvent = new AlterTableEvent(table, table,
-                                                          true, mockHandler);
+                                                          true, true, mockHandler);
 
     AlterExternalTable alterTable = new AlterExternalTable(alterTableEvent, TestUtil.initializeMockConfig());
 
@@ -114,9 +115,9 @@ public class AlterExternalTableTest
     Table newTable = TestUtil.initializeMockTable();
     newTable.getSd().getCols().add(new FieldSchema("new1", "int", null));
     newTable.getSd().getCols().add(new FieldSchema("new2", "string", null));
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     AlterTableEvent alterTableEvent = new AlterTableEvent(oldTable, newTable,
-                                                          true, mockHandler);
+                                                          true, true, mockHandler);
 
     AlterExternalTable alterTable = new AlterExternalTable(alterTableEvent, TestUtil.initializeMockConfig());
 
@@ -158,9 +159,9 @@ public class AlterExternalTableTest
     oldTable.getSd().getCols().add(new FieldSchema("old1", "int", null));
     oldTable.getSd().getCols().add(new FieldSchema("old2", "string", null));
     Table newTable = TestUtil.initializeMockTable();
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     AlterTableEvent alterTableEvent = new AlterTableEvent(oldTable, newTable,
-                                                          true, mockHandler);
+                                                          true, true, mockHandler);
 
     AlterExternalTable alterTable = new AlterExternalTable(alterTableEvent, TestUtil.initializeMockConfig());
 
@@ -203,9 +204,9 @@ public class AlterExternalTableTest
     Table newTable = TestUtil.initializeMockTable();
     newTable.getSd().getCols().add(new FieldSchema("new1", "int", null));
     newTable.getSd().getCols().add(new FieldSchema("new2", "string", null));
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     AlterTableEvent alterTableEvent = new AlterTableEvent(oldTable, newTable,
-                                                          true, mockHandler);
+                                                          true, true, mockHandler);
 
     AlterExternalTable alterTable = new AlterExternalTable(alterTableEvent, TestUtil.initializeMockConfig());
 

--- a/src/test/java/CreateTableTest.java
+++ b/src/test/java/CreateTableTest.java
@@ -7,6 +7,7 @@ import net.snowflake.hivemetastoreconnector.commands.CreateExternalTable;
 import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.events.CreateTableEvent;
@@ -313,7 +314,7 @@ public class CreateTableTest
     table.getSd().setCols(Arrays.asList(
         new FieldSchema("col1", "int", null),
         new FieldSchema("col2", "string", null)));
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     CreateTableEvent createTableEvent =
         new CreateTableEvent(table, true, TestUtil.initializeMockHMSHandler());
@@ -790,7 +791,7 @@ public class CreateTableTest
   {
     Table table = TestUtil.initializeMockTable();
 
-    HiveMetaStore.HMSHandler hmsHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler hmsHandler = TestUtil.initializeMockHMSHandler();
     CreateTableEvent createTableEvent =
         new CreateTableEvent(table, true, hmsHandler);
 

--- a/src/test/java/SnowflakeHiveListenerTest.java
+++ b/src/test/java/SnowflakeHiveListenerTest.java
@@ -7,6 +7,7 @@ import net.snowflake.hivemetastoreconnector.SnowflakeHiveListener;
 import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -54,7 +55,7 @@ public class SnowflakeHiveListenerTest
     table.setTableName("t1");
     table.setDbName("db1");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     DropTableEvent dropTableEvent = new DropTableEvent(table,
                                                        true, true, mockHandler);
 
@@ -87,7 +88,7 @@ public class SnowflakeHiveListenerTest
     table.setTableName("t1");
     table.setDbName("db1");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     DropTableEvent dropTableEvent = new DropTableEvent(table,
                                                        true, true, mockHandler);
 
@@ -125,7 +126,7 @@ public class SnowflakeHiveListenerTest
     table.setTableName("t1");
     table.setDbName("db1");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     DropTableEvent dropTableEvent = new DropTableEvent(table,
                                                        true, true, mockHandler);
 
@@ -163,7 +164,7 @@ public class SnowflakeHiveListenerTest
     table.setTableName("t1");
     table.setDbName("db1");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     DropTableEvent dropTableEvent = new DropTableEvent(table,
                                                        true, true, mockHandler);
 
@@ -201,7 +202,7 @@ public class SnowflakeHiveListenerTest
     table.setTableName("t1");
     table.setDbName("db1");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
     DropTableEvent dropTableEvent = new DropTableEvent(table,
                                                        true, true, mockHandler);
 
@@ -253,7 +254,7 @@ public class SnowflakeHiveListenerTest
     partition3.setSd(new StorageDescriptor());
     partition3.getSd().setLocation("s3://path/to/part3");
 
-    HiveMetaStore.HMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
+    IHMSHandler mockHandler = TestUtil.initializeMockHMSHandler();
 
     // Power Mockito cannot mix matchers and non-matchers. Get the config here
     SnowflakeConf mockConfig = TestUtil.initializeMockConfig();

--- a/src/test/java/TestUtil.java
+++ b/src/test/java/TestUtil.java
@@ -6,6 +6,7 @@ import net.snowflake.hivemetastoreconnector.SnowflakeConf;
 import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -29,7 +30,7 @@ public class TestUtil
    * Helper class to initialize the Hive metastore handler, which is commonly
    * used for tests in test classes.
    */
-  public static HiveMetaStore.HMSHandler initializeMockHMSHandler()
+  public static IHMSHandler initializeMockHMSHandler()
   {
     // Mock the HMSHandler and configurations
     Configuration mockConfig = PowerMockito.mock(Configuration.class);


### PR DESCRIPTION
Fix for Security vulnerabilities found in the Hive metastore connector by Snyk - https://snowflakecomputing.atlassian.net/browse/SNOW-623106

This PR updates the hive metastore to the required 3.1.3 version along with other required updates on dependent packages.