### PR TITLE
Update version of hive connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-hive-metastore-connector</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.1.4</version>
+            <version>3.2.4</version>
         </dependency>
         <dependency>
             <groupId>net.snowflake</groupId>
@@ -143,11 +143,6 @@
     	    <groupId>org.apache.hadoop</groupId>
     	    <artifactId>hadoop-mapreduce-client-core</artifactId>
     	    <version>3.1.4</version>
-	</dependency>
-	<dependency>
-    	    <groupId>org.apache.hadoop</groupId>
-    	    <artifactId>hadoop-mapred</artifactId>
-    	    <version>0.22.0</version>
 	</dependency>
     </dependencies>
 


### PR DESCRIPTION
Update version of Hive Snowflake connector to 0.6.1

- Update hadoop-common to v3.2.4
- Remove hadoop-mapred dependency