### PR TITLE
Support Lower Case Db and Schema names in Snowflake Hive connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.snowflake</groupId>
     <artifactId>snowflake-hive-metastore-connector</artifactId>
-    <version>0.6.1</version>
+    <version>0.6.2</version>
 
     <developers>
         <developer>

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/CreateExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/CreateExternalTable.java
@@ -80,11 +80,11 @@ public class CreateExternalTable extends Command
   public static String generateStageName(Table hiveTable,
                                          SnowflakeConf snowflakeConf)
   {
+    String dbName = snowflakeConf.get(SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_DB.getVarname(),null);
+
     return String.format(
         "%s__%s", // double underscore
-        StringUtil.escapeSqlIdentifier(snowflakeConf.get(
-            SnowflakeConf.ConfVars.SNOWFLAKE_JDBC_DB.getVarname(),
-            null)),
+        StringUtil.escapeSqlIdentifier(dbName.replace("\"", "")), // Remove quotes in the Database name that is used to create the Stage name to prevent Snowflake exception due to escaped quotes
         StringUtil.escapeSqlIdentifier(hiveTable.getTableName()));
   }
 

--- a/src/main/java/net/snowflake/hivemetastoreconnector/util/HiveToSnowflakeSchema.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/util/HiveToSnowflakeSchema.java
@@ -39,7 +39,13 @@ public class HiveToSnowflakeSchema {
         if (snowflakeSchemaSet.contains(hiveSchema.toLowerCase())) {
             log.info(hiveSchema + " is in the configured schema list.");
             return hiveSchema;
-        } else {
+        }
+        else if (snowflakeSchemaSet.contains("\"" + hiveSchema.toLowerCase() + "\"")) {
+            // Check if the hive schema is in the Snowflake schema list with quotes to support lower case schema names
+            log.info("\"" + hiveSchema + "\"" + " is in the configured schema list.");
+            return "\"" + hiveSchema + "\"";
+        }
+        else {
             log.info(hiveSchema + " is not in the configured schema list. " +
                     "Use default schema:" + snowflakeDefaultSchema);
             return snowflakeDefaultSchema;

--- a/src/test/java/AddPartitionTest.java
+++ b/src/test/java/AddPartitionTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class,
                     SnowflakeConf.class})
 

--- a/src/test/java/AlterExternalTableTest.java
+++ b/src/test/java/AlterExternalTableTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
  * Tests for generating the alter table command
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class})
 public class AlterExternalTableTest
 {

--- a/src/test/java/CreateTableTest.java
+++ b/src/test/java/CreateTableTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class,
                 DriverManager.class, Consumer.class, SnowflakeClient.class})
 

--- a/src/test/java/DropPartitionTest.java
+++ b/src/test/java/DropPartitionTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class})
 
 /**

--- a/src/test/java/DropTableTest.java
+++ b/src/test/java/DropTableTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
  * Tests for generating the drop table command
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class})
 public class DropTableTest
 {

--- a/src/test/java/HiveSyncToolTest.java
+++ b/src/test/java/HiveSyncToolTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Matchers.any;
  * Unit tests for the sync tool
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class,
                     DriverManager.class, SnowflakeConf.class,
                     SnowflakeClient.class, HiveSyncTool.class,

--- a/src/test/java/MiscTest.java
+++ b/src/test/java/MiscTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012-2019 Snowflake Computing Inc. All right reserved.
+ */
+
+import net.snowflake.hivemetastoreconnector.SnowflakeConf;
+import net.snowflake.hivemetastoreconnector.SnowflakeHiveListener;
+import net.snowflake.hivemetastoreconnector.core.SnowflakeClient;
+import net.snowflake.hivemetastoreconnector.util.HiveToSnowflakeSchema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
+@PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class,
+        SnowflakeClient.class, SnowflakeConf.class,
+        SnowflakeHiveListener.class})
+
+/**
+ * Miscellaneous Tests for the hive connector
+ */
+public class MiscTest
+{
+    /**
+     * A test to check if the correct schema from the schema list is chosen
+     * @throws Exception
+     */
+    @Test
+    public void verifySchemaSelectionWithQuotedSchemasCommandTest() throws Exception
+    {
+        Table table = TestUtil.initializeMockTable();
+
+        // Set a new hive db name
+        table.setDbName("testSchema");
+
+        // Mock config
+        SnowflakeConf mockConfig = TestUtil.initializeMockConfig();
+
+        PowerMockito
+                .when(mockConfig.get("snowflake.hive-metastore-listener.stage", null))
+                .thenReturn("aStage");
+
+        // Here, the default Snowflake schema will be chosen since the hive db name is not in the schema list
+        String chosenSchema = HiveToSnowflakeSchema.getSnowflakeSchemaFromHiveSchema(table.getDbName(), mockConfig);
+        assertEquals("Chosen schema does not match the expected default schema",
+                "someSchema1",
+                chosenSchema);
+
+        // Add testSchema in quotes to the schema list - this should still get matched with the Hive schema/DB name
+        PowerMockito
+                .when(mockConfig.getStringCollection("snowflake.hive-metastore-listener.schemas"))
+                .thenReturn(Arrays.asList(new String[]{"newSchema1", "\"testSchema\""}));
+
+        chosenSchema = HiveToSnowflakeSchema.getSnowflakeSchemaFromHiveSchema(table.getDbName(), mockConfig);
+        assertEquals("Chosen schema does not match the expected schema from schema list enclosed in quotes",
+                "\"testSchema\"",
+                chosenSchema);
+    }
+}

--- a/src/test/java/SnowflakeHiveListenerTest.java
+++ b/src/test/java/SnowflakeHiveListenerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.times;
  * Tests for the SnowflakeHiveListener
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "jdk.internal.reflect.*"})
 @PrepareForTest({Configuration.class, HiveMetaStore.HMSHandler.class,
                     SnowflakeClient.class, SnowflakeConf.class,
                     SnowflakeHiveListener.class})


### PR DESCRIPTION
Support Lower Case Db and Schema names in Snowflake Hive connector

There was 2 issues in the Hive Connector when trying to use lower case objects that this PR addresses. 
1) If a DB name in Snowflake was in lower case, the Hive config would have the name within quotes - the quotes would be escaped when trying to create a stage (in case a default stage is not provided), which would result in an exception from Snowflake.
2) If the Snowflake schema was in lower case, the schema list in Hive config would have the name within quotes - however, since the hive schema does not have quotes, the quoted schema in the list would not match with the hive schema, thereby resulting in all the tables being created in the default schema.

Jira tasks:
https://snowflakecomputing.atlassian.net/browse/SNOW-664143
https://snowflakecomputing.atlassian.net/browse/SNOW-664550

