### PR TITLE
SNOW-1050045 Remove the import command for custom script actions

### DIFF
--- a/scripts/add_snowflake_hive_metastore_connector_script_action.sh
+++ b/scripts/add_snowflake_hive_metastore_connector_script_action.sh
@@ -20,10 +20,6 @@ CUSTOMHIVELIBSDIR=/usr/hdp/2.6.5.3032-3/atlas/hook/hive
 # Where the snowflake-config.xml should go (WILL VARY BY USER -- please edit)
 SNOWFLAKECONFDIR=/usr/hdp/current/hive-server2/conf/conf.server
 
-echo "Importing helper module"
-# Import helper module
-source <(wget -q -O - https://hdiconfigactions.blob.core.windows.net/linuxconfigactionmodulev01/HDInsightUtilities-v01.sh)
-
 # Check paths exist
 if [ -e $CUSTOMHIVELIBSDIR ]; then
   echo "$CUSTOMHIVELIBSDIR exists"

--- a/scripts/add_snowflake_hive_metastore_connector_script_action.sh
+++ b/scripts/add_snowflake_hive_metastore_connector_script_action.sh
@@ -22,7 +22,7 @@ SNOWFLAKECONFDIR=/usr/hdp/current/hive-server2/conf/conf.server
 
 echo "Importing helper module"
 # Import helper module
-wget -O /tmp/HDInsightUtilities-v01.sh -q https://hdiconfigactions.blob.core.windows.net/linuxconfigactionmodulev01/HDInsightUtilities-v01.sh && source /tmp/HDInsightUtilities-v01.sh && rm -f /tmp/HDInsightUtilities-v01.sh
+source <(wget -q -O - https://hdiconfigactions.blob.core.windows.net/linuxconfigactionmodulev01/HDInsightUtilities-v01.sh)
 
 # Check paths exist
 if [ -e $CUSTOMHIVELIBSDIR ]; then


### PR DESCRIPTION
This change slightly improves the example script for Hive metastore setup on HDInsight clusters via custom script actions.

Previously, we used the import command mentioned [here](https://learn.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-script-actions-linux#helpermethods). However, we don't need the helper functions elsewhere in the script, we only need to use `hadoop fs` commands to copy files over to predefined locations.