### PR TITLE
Backmerge upstream master (JDBC 3.12.11 -> 3.24.2)

### DIFF
--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
@@ -182,7 +182,7 @@ public class AlterExternalTable extends Command
   {
       return ImmutableList.of(
          String.format("ALTER EXTERNAL TABLE IF EXISTS %s REFRESH;",
-             StringUtil.escapeSqlIdentifier(newTable.getTableName())));
+             StringUtil.escapeSqlIdentifier(newHiveTable.getTableName())));
   }
 
   /**

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
@@ -255,7 +255,7 @@ public class AlterExternalTable extends Command
                                                 snowflakeConf));
     }
 
-    if (!Objects.equal(oldTable.getSd().getLocation(), newTable.getSd().getLocation())) {
+    if (!Objects.equal(oldHiveTable.getSd().getLocation(), newHiveTable.getSd().getLocation())) {
       commands.addAll(generateAlterStageSetURLSqlQueries());
       commands.addAll(generateRefreshTableSqlQueries());
     }

--- a/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
+++ b/src/main/java/net/snowflake/hivemetastoreconnector/commands/AlterExternalTable.java
@@ -180,9 +180,9 @@ public class AlterExternalTable extends Command
 
   public List<String> generateRefreshTableSqlQueries()
   {
-      return ImmutableList.of(
-         String.format("ALTER EXTERNAL TABLE IF EXISTS %s REFRESH;",
-             StringUtil.escapeSqlIdentifier(newHiveTable.getTableName())));
+    return ImmutableList.of(
+        String.format("ALTER EXTERNAL TABLE IF EXISTS %s REFRESH;",
+            StringUtil.escapeSqlIdentifier(newHiveTable.getTableName())));
   }
 
   /**
@@ -255,9 +255,19 @@ public class AlterExternalTable extends Command
                                                 snowflakeConf));
     }
 
-    if (!Objects.equal(oldHiveTable.getSd().getLocation(), newHiveTable.getSd().getLocation())) {
+    if (!Objects.equal(oldHiveTable.getSd().getLocation(), newHiveTable.getSd().getLocation()))
+    {
       commands.addAll(generateAlterStageSetURLSqlQueries());
       commands.addAll(generateRefreshTableSqlQueries());
+    }
+    else
+    {
+	String message = String.format("old %s[location=%s] -> new %s[location=%s]",
+				       oldHiveTable.getTableName(),
+				       oldHiveTable.getSd().getLocation(),
+				       newHiveTable.getTableName(),
+				       newHiveTable.getSd().getLocation());
+	commands.addAll(new LogCommand(oldHiveTable, message).generateSqlQueries());
     }
 
     return commands;


### PR DESCRIPTION
## Summary

Backmerge of upstream `snowflakedb/snowflake-hive-metastore-connector` `master` into our fork's `master`, via a real merge commit (`git merge upstream/master`, upstream history preserved — not squashed or rebased).

We were 5 commits behind / 8 ahead of upstream, with **zero file overlap**, so the merge is textually clean (no conflicts). The 5 upstream commits we lacked touch exactly two files:

- `pom.xml` — project version `0.6.3` -> `0.6.4`, and **`snowflake-jdbc` `3.12.11` -> `3.24.2`** (this is the substantive change — ~5 years of driver evolution).
- `scripts/add_snowflake_hive_metastore_connector_script_action.sh` — deletes 4 lines that `wget`-ed and sourced `HDInsightUtilities-v01.sh` from an Azure blob at install time. This only applied to Azure HDInsight provisioning; we build our own Hive docker image, so it's inert for us.

Our fork's customisation — `AlterExternalTable.java` (rename-table support + OPS-5169 alter-stage-set-location work) — is **untouched** by this merge; upstream never touches that file.

## Build/test evidence

- `mvn -B clean test` run under **JDK 1.8.0_482 (Temurin)**, matching the project's configured `maven-compiler-plugin` source/target of `1.8`.
- Result: **41 tests run, 0 failures, 0 errors, 0 skipped. BUILD SUCCESS.**
- `mvn dependency:tree` shows `snowflake-jdbc:3.24.2` resolves cleanly with no convergence conflicts.
- Caveat: the test suite mocks the JDBC connection entirely via PowerMock (`SnowflakeConnectionV1` is PowerMock-mocked in `TestUtil.java`) — no test opens a real Snowflake connection. Green tests confirm the SQL-generation/command logic compiles and runs against the new driver's API surface, not live driver behavior.
- Also ran the same suite under JDK 21 (Zulu) for comparison: it fails identically on **both** the pre-merge and post-merge commit with `InaccessibleObjectException` from PowerMock's reflection Whitebox (`opens java.lang` not granted to unnamed module) — a pre-existing PowerMock/JDK17+ incompatibility unrelated to this bump, not something introduced by it.

## Version / release-process follow-up (not changed in this PR)

- This repo has **no Makefile** (unlike assumed) — release is driven by `deploy.sh`, which reads the project version dynamically from `pom.xml` via `scripts/get_project_info_from_pom.py`, so no manual version-string edit is needed here.
- No Dockerfile, docker-compose, or CI workflow file in this repo references the connector version or a JDBC version string.
- If a separate Hive docker image repo pins this connector's version or JDBC version, that would need a follow-up bump there — out of scope for this PR.

## Push access

Pushed `fm/connbm` to `origin` (`tubular/snowflake-hive-metastore-connector`) successfully — no 403, no pull-only restriction encountered.

Do not merge.
